### PR TITLE
Splash updates

### DIFF
--- a/client/app/Main.hs
+++ b/client/app/Main.hs
@@ -45,10 +45,6 @@ main = do
     existingUncaughtHandler e
     visuallyCrash e
 
-  js_signalEstuaryLoaded
-  -- Wait for 10k ms or click, which ever happens first
-  waitForInteractionOrTimeout 10000
-
   mainBusNodes@(mainBusIn,_,_,_) <- initializeMainBus
   wd <- liftAudioIO $ newWebDirt mainBusIn
   initializeWebAudio wd
@@ -60,9 +56,9 @@ main = do
   ri <- newMVar $ emptyRenderInfo
   forkRenderThread c ri
 
-  -- root <- fmap pFromJSVal js_estuaryMountPoint :: IO HTMLDivElement
-  -- mainWidgetAtRoot root $ estuaryWidget Splash c ri protocol
   mainWidgetInElementById "estuary-root" $ estuaryWidget Splash c ri protocol
+
+  js_setIconStateLoaded
 
 visuallyCrash :: SomeException -> IO ()
 visuallyCrash e =
@@ -73,27 +69,12 @@ visuallyCrash e =
         ]
   in js_confirmReload $ toJSString $ intercalate "\n" lines
 
-waitForInteractionOrTimeout :: Int -> IO ()
-waitForInteractionOrTimeout ms = do
-  timeout (ms * 1000) js_waitForClickBody
-  return ()
-
-{- disactivated temporarily in update to new reflex
-mainWidgetAtRoot :: (IsHTMLElement e) => e -> Widget Spider (Gui Spider (WithWebView SpiderHost) (HostFrame Spider)) () -> IO ()
-mainWidgetAtRoot root widget = runWebGUI $ \webView -> do
-  Just doc <- liftM (fmap castToHTMLDocument) $ webViewGetDomDocument webView
-  attachWidget root webView widget -}
-
 foreign import javascript unsafe
   "if (window.confirm($1)) {        \
   \  window.___forcedReload = true; \
   \  window.location.reload();      \
   \}"
   js_confirmReload :: JSVal -> IO ()
-
-foreign import javascript interruptible
-  "document.body.addEventListener('click', $c, {once: true});"
-  js_waitForClickBody :: IO ()
 
 foreign import javascript safe
   "window.addEventListener('beforeunload', function (e) { \
@@ -109,5 +90,5 @@ foreign import javascript safe
   js_estuaryMountPoint :: IO JSVal
 
 foreign import javascript safe
-  "document.querySelector('#estuary-splash').classList.add('btn')"
-  js_signalEstuaryLoaded :: IO ()
+  "EstuaryIcon.state = 'loaded';"
+  js_setIconStateLoaded :: IO () 

--- a/client/src/Estuary/Widgets/EstuaryIcon.hs
+++ b/client/src/Estuary/Widgets/EstuaryIcon.hs
@@ -1,4 +1,6 @@
-module Estuary.Widgets.EstuaryIcon where
+module Estuary.Widgets.EstuaryIcon (
+  estuaryIcon
+) where
 
 import Control.Monad.IO.Class(liftIO)
 
@@ -23,29 +25,12 @@ import Reflex.Dom
 
 estuaryIcon :: (MonadWidget t m) => m ()
 estuaryIcon = do
-  postMountEv <- getPostBuild
-
   jsIconInstance <- liftIO $ js_splashIconInstance
-  jsContainerEl <- liftIO $ (fmap pFromJSVal js_splashScreenContainerEl :: IO (Maybe Dom.Element))
   jsCanvas <- liftIO $ (fmap pFromJSVal (js_getCanvas jsIconInstance) :: IO (Dom.Element))
   
-  case jsContainerEl of
-
-    -- Animate, we are transitioning from the splash screen.
-    Just screen -> do
-      let duration = 3 -- seconds
-      startPos <- liftIO $ js_snapshotPosition jsIconInstance
-      placeRawElement jsCanvas
-      liftIO $ do
-        js_animateFrom jsIconInstance startPos duration
-        classList <- Element.getClassList screen
-        ClassList.add classList ["loaded"]
-
-    -- Don't animate, we are not transitioning from the splash screen.
-    Nothing -> placeRawElement jsCanvas
+  placeRawElement jsCanvas
 
 newtype IconDisplay = IconDisplay JSVal
-newtype BBox = BBox JSVal
 
 foreign import javascript safe
   "EstuaryIcon != null ? EstuaryIcon.display : null"
@@ -54,15 +39,3 @@ foreign import javascript safe
 foreign import javascript safe
   "$1.canvas"
   js_getCanvas :: IconDisplay -> IO JSVal
-
-foreign import javascript safe
-  "document.querySelector('#estuary-splash:not(.loaded)')"
-  js_splashScreenContainerEl :: IO JSVal
-
-foreign import javascript safe
-  "EstuaryIcons.snapshotPosition($1)"
-  js_snapshotPosition :: IconDisplay -> IO BBox
-
-foreign import javascript safe
-  "EstuaryIcons.animateFrom($1, $2, $3);"
-  js_animateFrom :: IconDisplay -> BBox -> Double -> IO ()

--- a/client/stack.yaml
+++ b/client/stack.yaml
@@ -40,7 +40,7 @@ packages:
 
 - location:
     git: https://github.com/dktr0/MusicW.git
-    commit: 94830ba9f5929abbd09094bc5d21d44c6a88a889
+    commit: d7d4c57a54f47eb60144dbd36e16009ae5d73925
   extra-dep: true
 
 - location:

--- a/static/estuary-icon.js
+++ b/static/estuary-icon.js
@@ -1,4 +1,4 @@
-;var EstuaryIcons = (function() {
+var EstuaryIcons = (function() {
   var MAX_COLOR_VALUE = 255;
   var CENTER_VARIATION_RADIUS = 0.03125; // % of width or height for x or y resp
   var PADDING = 0.03125; // % of width or height
@@ -74,7 +74,7 @@
 
     this.running = false;
 
-    /** @member {Display} */
+    /** @member {Display[]} */
     this.displays = [];
 
     this.renderStartTime = NaN;
@@ -119,7 +119,7 @@
     // TODO limit to 60fps to allow for GC in between
 
     var numLinesNow = Math.max(0, Math.floor(timeSinceStart * this.linesPerSec));
-    var numLinesToDraw = numLinesNow - this.lineCount;
+    var numLinesToDraw = Math.min(numLinesNow - this.lineCount, 100); // Limit this incase it gets put in the background for a day
 
     this.lineCount = numLinesNow;
 
@@ -208,7 +208,6 @@
         if (progress > 1) {
           delete display.animation;
           display.canvas.style.transform = '';
-          display.canvas.style.position = '';
         } else {
           doTransitionFrame(animation.startPos, animation.endPos, progress, display.canvas);
         }

--- a/static/index.html.template
+++ b/static/index.html.template
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <link defer href="../css-custom/classic.css" rel="stylesheet" type="text/css" id="estuary-current-theme"/>
-  <link defer href="../css-source/source.css" rel="stylesheet" type="text/css"/>
+  <link href="../css-custom/classic.css" rel="stylesheet" type="text/css" id="estuary-current-theme"/>
+  <link href="../css-source/source.css" rel="stylesheet" type="text/css"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <script defer type="text/javascript" src="EstuaryProtocol.js"></script>
@@ -35,12 +35,19 @@
       display: flex;
     }
 
+    .estuary-icon-display.center-screen {
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      position: fixed;
+    }
+
     .estuary-icon-display {
       margin: auto;
       max-width: 100%;
       max-height: 100%;
       z-index: 10;
-      position: relative; /* must be positioned so that z-index has an effect. */
+      position: relative;
     }
 
     div#estuary-splash {
@@ -49,8 +56,38 @@
     }
 
     div#estuary-splash.loaded {
+      cursor: pointer;
+    }
+
+    div#estuary-splash.started {
       opacity: 0;
       pointer-events: none;
+    }
+
+    div#estuary-splash .info {
+      padding: 5vh 5vw;
+      z-index: 20;
+      position: fixed;
+      color: rgb(98, 221, 115); /* estuary green */
+      font-family: 'estuaryFont';
+    }
+
+    div#estuary-splash .info .title {
+      font-size: 7vh;
+      margin-bottom: 0;
+    }
+
+    div#estuary-splash .info .status {
+      font-size: 3vh;
+      margin-top: 0.5em;
+    }
+
+    div#estuary-splash.started .info {
+      display: none;
+    }
+
+    div#estuary-splash .status {
+      padding: 0 1em;
     }
   </style>
   <script type="text/javascript" src="estuary-icon.js"></script>
@@ -59,10 +96,16 @@
 <body>
   <div id="estuary-root"></div>
 #ifndef TEST
-  <div id="estuary-splash" class="estuary-logo full-screen"></div>
+  <div id="estuary-splash" class="estuary-logo full-screen">
+    <div class="info">
+      <h1 class="title">Estuary</h1>
+      <h5 class="status">Loading...</h5>
+    </div>
+  </div>
   <script type="text/javascript">
     var EstuaryIcon = (function() {
       var container = document.querySelector('#estuary-splash');
+      var statusDisplay = container.querySelector('.status');
 
       var icons = new EstuaryIcons(800, 800, {
         linesPerSec: 15,
@@ -73,10 +116,49 @@
 
       icons.startRendering();
 
-      return {
+      var splash = {
+        claim: container,
         display: display,
         renderer: icons
       };
+
+      var state = '';
+      Object.defineProperty(splash, 'state', {
+        enumerable: true,
+        configurable: true,
+        get: function get() { return state; },
+        set: function set(nextState) {
+          switch (nextState) {
+            case 'loading':
+              // The app is loading and no interaction is available yet.
+              container.classList = 'estuary-logo full-screen';
+              display.canvas.classList.add('center-screen');
+              statusDisplay.innerText = 'Loading...';
+              container.appendChild(display.canvas);
+              break;
+            case 'loaded':
+              // The app has loaded and the splash is ready to click.
+              container.classList = 'estuary-logo full-screen loaded';
+              statusDisplay.innerText = 'Click to start';
+              container.addEventListener('click', function() {
+                splash.state = 'started';
+              }, {once: true});
+              break;
+            case 'started':
+              // The app has loaded and the splash was clicked.
+              container.classList = 'estuary-logo full-screen started';
+              var startPos = EstuaryIcons.snapshotPosition(display); 
+              display.canvas.classList.remove('center-screen');
+              EstuaryIcons.animateFrom(display, startPos, /* duration */ 3);
+              break;
+          }
+
+          state = nextState;
+        }
+      });
+      splash.state = 'loading';
+
+      return splash;
     })();
   </script>
 #endif

--- a/static/index.html.template
+++ b/static/index.html.template
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8"/>
+  
   <link href="../css-custom/classic.css" rel="stylesheet" type="text/css" id="estuary-current-theme"/>
   <link href="../css-source/source.css" rel="stylesheet" type="text/css"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
Adds the name `Estuary` to the start page as well as a short status message indicating `Loading...` or `Click to start` depending on the state of the app that loads behind it.

This also changes the rendering so that the app is also mounted prior to setting the status as loaded which prevents and annoying flicker for the initial render as it is now hidden. The splash more smoothly transitions to the loaded app.

The icon will no longer fade (since there are directions on what to do) and after the initial click, the audio context will be resumed. This depends on dktr0/MusicW#2 for that.

Fixes #48.