### PR TITLE
Support switching the mainBus' destination.

### DIFF
--- a/client/src/Estuary/Render/DynamicsMode.hs
+++ b/client/src/Estuary/Render/DynamicsMode.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ScopedTypeVariables, RankNTypes #-}
 module Estuary.Render.DynamicsMode where 
 
 import Sound.MusicW
@@ -66,3 +67,10 @@ changeDynamicsMode (input,preGain,comp,postGain) WideDynamics = liftAudioIO $ do
   setValue comp Release 0.100
   setValue postGain Gain (dbamp (-20))
   return ()
+
+changeDestination :: (Node, Node, Node, Node) -> (forall m. AudioIO m => m Node) -> IO Node
+changeDestination (_, _, _, postGain) destCreator = liftAudioIO $ do
+  newDest <- destCreator
+  liftIO $ disconnectAll postGain
+  connectNodes postGain newDest
+  return newDest

--- a/client/stack.yaml
+++ b/client/stack.yaml
@@ -40,7 +40,7 @@ packages:
 
 - location:
     git: https://github.com/dktr0/MusicW.git
-    commit: d7d4c57a54f47eb60144dbd36e16009ae5d73925
+    commit: 7ca02828637004611cdd5b6691ea365aee7d3b17
   extra-dep: true
 
 - location:


### PR DESCRIPTION
Depends on dktr0/MusicW#4.

Support changing the destination of the mainBus. It disconnects the postGain and reconnects it to the new target.

Add a magic export `___setEstuaryAudioDestination` on `window` that when called with `'stream'` will set the destination to a media stream and return that node (which holds the stream in the `stream` field). Would like to use this to stream audio from Estuary to other places but this functionality shouldn't be exposed in the ui until a less hacky use case comes up. For now, accessing through the js console seems fine.