### PR TITLE
Assume local peer server is unsecure even when estuary served over https

### DIFF
--- a/static/PeerProtocol.js
+++ b/static/PeerProtocol.js
@@ -16,6 +16,7 @@ PeerProtocol.prototype.startStreaming = function() {
   this.peer = new Peer({
     debug: true,
     host: 'localhost',
+    secure: false,
     port: 9000,
     path: '/peers'
   });


### PR DESCRIPTION
The peer server is run on localhost which is more likely unsecure. When unset, peerjs assumes secure if the context of the page making the request is also secure which estuary is now. The peer server should likely be configurable in the future but `secure: false` is the better default for now so that connecting to a simple localhost setup works.