### PR TITLE
makeSampleMap mention in building for development section

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -107,5 +107,6 @@ In the **backend** shell (`shells.ghc`) build the server, put it in the staging 
 [nix-shell: ...]$ make cabalBuildServer
 [nix-shell: ...]$ make cabalStageServer
 [nix-shell: ...]$ make devStageSamples
+[nix-shell: ...]$ make makeSampleMap  # Only required if you haven't done a full build
 [nix-shell: ...]$ make runDevServer
 ```


### PR DESCRIPTION
If a full build is done before building development this isn't required but if people are going straight to building for development they'll need to run this additional command.