### PR TITLE
Small fix for error syntax widget

### DIFF
--- a/client/src/Estuary/Widgets/Text.hs
+++ b/client/src/Estuary/Widgets/Text.hs
@@ -76,10 +76,10 @@ textProgramWidget ctx errorText rows i delta = divClass "textPatternChain" $ do 
     d' <- dropdown initialParser parserMap $ ((def :: DropdownConfig t TidalParser) & attributes .~ constDyn ("class" =: "ui-dropdownMenus code-font primary-color primary-borders")) & dropdownConfig_setValue .~ parserFuture
     evalButton' <- divClass "textInputLabel" $ do
       x <- dynButton =<< translateDyn Term.Eval ctx
-      e' <- holdUniqDyn errorText
-      let y = fmap (maybe (return ()) (syntaxErrorWidget ctx)) $ updated e'
-      widgetHold (return ()) y
       return x
+    e' <- holdUniqDyn errorText
+    let y = fmap (maybe (return ()) (syntaxErrorWidget ctx)) $ updated e'
+    widgetHold (return ()) y
     infoButton' <- divClass "referenceButton" $ dynButton "?"
     return (d',evalButton',infoButton')
 

--- a/static/css-source/source.css
+++ b/static/css-source/source.css
@@ -1111,6 +1111,8 @@ display: inline-flex;
     width: 100%;
     border: none;
    	padding: 0.125em;
+}
+
 /* Tooltip classes */
 
 .tooltip {


### PR DESCRIPTION
Once I built with the latest changes from the dev branch the syntaxt error widget was appearing on a new line. Makes sense to take it out of textInputLabel anyway. And there was a missing '}' in the stylesheet from a merge conflict resolution. Looking good now!