### PR TITLE
No wrapper for the ensembleStatusWidget

### DIFF
--- a/client/src/Estuary/Types/View/Presets.hs
+++ b/client/src/Estuary/Types/View/Presets.hs
@@ -82,6 +82,39 @@ presetViews = fromList [
       BorderDiv (Views [LabelView 17,TextView 18 0])
       ]),
 
+      ("twobysix",  GridView 2 6 [
+      BorderDiv (Views [LabelView 0,TextView 1 0]),
+      BorderDiv (Views [LabelView 2,TextView 3 0]),
+      BorderDiv (Views [LabelView 4,TextView 5 0]),
+      BorderDiv (Views [LabelView 6,TextView 7 0]),
+      BorderDiv (Views [LabelView 8,TextView 9 0]),
+      BorderDiv (Views [LabelView 10,TextView 11 0]),
+      BorderDiv (Views [LabelView 12,TextView 13 0]),
+      BorderDiv (Views [LabelView 14,TextView 15 0]),
+      BorderDiv (Views [LabelView 15,TextView 16 0]),
+      BorderDiv (Views [LabelView 17,TextView 18 0]),
+      BorderDiv (Views [LabelView 19,TextView 20 0]),
+      BorderDiv (Views [LabelView 21,TextView 22 0])
+      ]),
+
+      ("threebyfive",  GridView 3 5 [
+      BorderDiv (Views [LabelView 0,TextView 1 0]),
+      BorderDiv (Views [LabelView 2,TextView 3 0]),
+      BorderDiv (Views [LabelView 4,TextView 5 0]),
+      BorderDiv (Views [LabelView 6,TextView 7 0]),
+      BorderDiv (Views [LabelView 8,TextView 9 0]),
+      BorderDiv (Views [LabelView 10,TextView 11 0]),
+      BorderDiv (Views [LabelView 12,TextView 13 0]),
+      BorderDiv (Views [LabelView 14,TextView 15 0]),
+      BorderDiv (Views [LabelView 15,TextView 16 0]),
+      BorderDiv (Views [LabelView 17,TextView 18 0]),
+      BorderDiv (Views [LabelView 19,TextView 20 0]),
+      BorderDiv (Views [LabelView 21,TextView 22 0]),
+      BorderDiv (Views [LabelView 22,TextView 23 0]),
+      BorderDiv (Views [LabelView 24,TextView 25 0]),
+      BorderDiv (Views [LabelView 25,TextView 26 0])
+      ]),
+
       ("threebysix", GridView 3 6  [
       BorderDiv (Views [LabelView 0,TextView 1 0]),
       BorderDiv (Views [LabelView 2,TextView 3 0]),
@@ -101,6 +134,29 @@ presetViews = fromList [
       BorderDiv (Views [LabelView 30,TextView 31 0]),
       BorderDiv (Views [LabelView 32,TextView 33 0]),
       BorderDiv (Views [LabelView 34,TextView 35 0])
+      ]),
+
+      ("threebyseven", GridView 3 7  [
+      BorderDiv (Views [LabelView 0,TextView 1 0]),
+      BorderDiv (Views [LabelView 2,TextView 3 0]),
+      BorderDiv (Views [LabelView 4,TextView 5 0]),
+      BorderDiv (Views [LabelView 6,TextView 7 0]),
+      BorderDiv (Views [LabelView 8,TextView 9 0]),
+      BorderDiv (Views [LabelView 10,TextView 11 0]),
+      BorderDiv (Views [LabelView 12,TextView 13 0]),
+      BorderDiv (Views [LabelView 14,TextView 15 0]),
+      BorderDiv (Views [LabelView 16,TextView 17 0]),
+      BorderDiv (Views [LabelView 18,TextView 19 0]),
+      BorderDiv (Views [LabelView 20,TextView 21 0]),
+      BorderDiv (Views [LabelView 22,TextView 23 0]),
+      BorderDiv (Views [LabelView 24,TextView 25 0]),
+      BorderDiv (Views [LabelView 26,TextView 27 0]),
+      BorderDiv (Views [LabelView 28,TextView 29 0]),
+      BorderDiv (Views [LabelView 30,TextView 31 0]),
+      BorderDiv (Views [LabelView 32,TextView 33 0]),
+      BorderDiv (Views [LabelView 34,TextView 35 0]),
+      BorderDiv (Views [LabelView 35,TextView 36 0]),
+      BorderDiv (Views [LabelView 37,TextView 38 0])
       ]),
 
       ("fourbyseven", GridView 4 7  [
@@ -220,6 +276,6 @@ presetViews = fromList [
          (Views [LabelView 12,TextView 13 0]),
          (Views [LabelView 14,TextView 15 0]),
          (Views [LabelView 16,TextView 17 0]),
-          ViewDiv "ensembleStatusView" EnsembleStatusView
+         (Views [TempoView,EnsembleStatusView])
         ])
       ]

--- a/static/css-source/source.css
+++ b/static/css-source/source.css
@@ -1068,40 +1068,41 @@ display: inline-flex;
 /* ///////////status Widget/////////// */
 
 
-.ensembleStatusView {
+.tableContainer {
   overflow: hidden;
   overflow-y: auto;
+  border: 1px solid var(--primary-color);
   border-radius: 5px;
-  box-shadow: 0px 0.25px 4px 0.025px;
-
+  margin-bottom: 0.5%;
 }
 
-.ensembleStatusView::-webkit-scrollbar  {
-    width: 1%;
+.tableContainer::-webkit-scrollbar  {
+    width: 2%;
     height: 0px;
 }
 
-.ensembleStatusView::-webkit-scrollbar-track {
+.tableContainer::-webkit-scrollbar-track {
   box-shadow: inset 0 0 5px var(--primary-color);
   border-radius: 10px;
 }
 
-.ensembleStatusView::-webkit-scrollbar-thumb {
-  background: var(--primary-color);;
+.tableContainer::-webkit-scrollbar-thumb {
+  background: var(--primary-color);
   border-radius: 10px;
 }
 
-.ensembleStatusView::-webkit-scrollbar-corner{
+.tableContainer::-webkit-scrollbar-corner{
 	background-color: transparent;
-
 }
 
 
 .ensemble-name {
 	text-align:center;
 	padding: 0.125em;
-	box-shadow: 0px 1px 3px 0px;
+	border: 1px solid var(--primary-color);
+	border-radius: 5px;
 }
+
 
 
 .tableContainer table {

--- a/static/css-source/source.css
+++ b/static/css-source/source.css
@@ -1077,7 +1077,7 @@ display: inline-flex;
 }
 
 .tableContainer::-webkit-scrollbar  {
-    width: 2%;
+    width: 1%;
     height: 0px;
 }
 
@@ -1095,14 +1095,12 @@ display: inline-flex;
 	background-color: transparent;
 }
 
-
 .ensemble-name {
 	text-align:center;
 	padding: 0.125em;
 	border: 1px solid var(--primary-color);
 	border-radius: 5px;
 }
-
 
 
 .tableContainer table {


### PR DESCRIPTION
Hi David, 

I got rid of the wrapper of the ensembleStatusWidget and instead, I added the scrollbar and the overflow-y: auto to the table div. This way the ensembleStatusWidget works fine with the View and BorderDiv views. I also added three new presets: "twobysix", "threebyfive" and "threebyseven". I will continue fixing other problems related to the table on Monday. Best. 