### PR TITLE
Toggle terminal improvements

### DIFF
--- a/client/src/Estuary/Widgets/Estuary.hs
+++ b/client/src/Estuary/Widgets/Estuary.hs
@@ -50,6 +50,7 @@ import Estuary.Widgets.Footer
 import Estuary.Types.EnsembleC
 import Estuary.Types.Ensemble
 import Estuary.Render.Renderer
+import Estuary.Widgets.Terminal
 
 keyboardHintsCatcher :: MonadWidget t m => ImmutableRenderContext -> MVar Context -> MVar RenderInfo -> m ()
 keyboardHintsCatcher irc ctxM riM = mdo
@@ -82,7 +83,8 @@ estuaryWidget irc ctxM riM keyboardHints = divClass "estuary" $ mdo
   -- three GUI components: header, main (navigation), footer
   headerChange <- header ctx
   (requests, ensembleRequestFromPage, hintsFromPage) <- divClass "page ui-font" $ navigation ctx renderInfo deltasDown
-  command <- footer ctx renderInfo deltasDown hints
+  command <- terminalWidget ctx deltasDown hints
+  footer ctx renderInfo
   let commandRequests = attachWithMaybe commandToRequest (current ensembleCDyn) command
   let ensembleRequests = leftmost [commandRequests, ensembleRequestFromPage,ensembleRequestsFromHints]
 

--- a/client/src/Estuary/Widgets/Estuary.hs
+++ b/client/src/Estuary/Widgets/Estuary.hs
@@ -85,7 +85,7 @@ estuaryWidget irc ctxM riM keyboardHints = divClass "estuary" $ mdo
   headerChange <- header ctx
   (requests, ensembleRequestFromPage, hintsFromPage) <- divClass "page ui-font" $ navigation ctx renderInfo deltasDown
   let terminalShortcut = ffilter (elem ToggleTerminal) hints
-  let terminalEvent = terminalShortcut -- or terminalButton
+  let terminalEvent = leftmost [() <$ terminalShortcut, terminalButton]
   terminalVisible <- toggle False terminalEvent
   command <- hideableWidget' terminalVisible $ do
     terminalWidget ctx deltasDown hints

--- a/client/src/Estuary/Widgets/Estuary.hs
+++ b/client/src/Estuary/Widgets/Estuary.hs
@@ -86,7 +86,7 @@ estuaryWidget irc ctxM riM keyboardHints = divClass "estuary" $ mdo
   (requests, ensembleRequestFromPage, hintsFromPage) <- divClass "page ui-font" $ navigation ctx renderInfo deltasDown
   let terminalEvent = ffilter (elem ToggleTerminal) hints
   terminalVisible <- toggle False terminalEvent
-  command <- hideableWidget'' terminalVisible "terminal" "terminal-hidden" $ do
+  command <- hideableWidget' terminalVisible $ do
     terminalWidget ctx deltasDown hints
   footer ctx renderInfo
   let commandRequests = attachWithMaybe commandToRequest (current ensembleCDyn) command

--- a/client/src/Estuary/Widgets/Estuary.hs
+++ b/client/src/Estuary/Widgets/Estuary.hs
@@ -84,11 +84,12 @@ estuaryWidget irc ctxM riM keyboardHints = divClass "estuary" $ mdo
   -- four GUI components: header, main (navigation), terminal, footer
   headerChange <- header ctx
   (requests, ensembleRequestFromPage, hintsFromPage) <- divClass "page ui-font" $ navigation ctx renderInfo deltasDown
-  let terminalEvent = ffilter (elem ToggleTerminal) hints
+  let terminalShortcut = ffilter (elem ToggleTerminal) hints
+  let terminalEvent = terminalShortcut -- or terminalButton
   terminalVisible <- toggle False terminalEvent
   command <- hideableWidget' terminalVisible $ do
     terminalWidget ctx deltasDown hints
-  footer ctx renderInfo
+  terminalButton <- footer ctx renderInfo
   let commandRequests = attachWithMaybe commandToRequest (current ensembleCDyn) command
   let ensembleRequests = leftmost [commandRequests, ensembleRequestFromPage,ensembleRequestsFromHints]
 

--- a/client/src/Estuary/Widgets/Estuary.hs
+++ b/client/src/Estuary/Widgets/Estuary.hs
@@ -51,6 +51,7 @@ import Estuary.Types.EnsembleC
 import Estuary.Types.Ensemble
 import Estuary.Render.Renderer
 import Estuary.Widgets.Terminal
+import Estuary.Widgets.Generic
 
 keyboardHintsCatcher :: MonadWidget t m => ImmutableRenderContext -> MVar Context -> MVar RenderInfo -> m ()
 keyboardHintsCatcher irc ctxM riM = mdo
@@ -80,10 +81,13 @@ estuaryWidget irc ctxM riM keyboardHints = divClass "estuary" $ mdo
 
   let ensembleCDyn = fmap ensembleC ctx
 
-  -- three GUI components: header, main (navigation), footer
+  -- four GUI components: header, main (navigation), terminal, footer
   headerChange <- header ctx
   (requests, ensembleRequestFromPage, hintsFromPage) <- divClass "page ui-font" $ navigation ctx renderInfo deltasDown
-  command <- terminalWidget ctx deltasDown hints
+  let terminalEvent = ffilter (elem ToggleTerminal) hints
+  terminalVisible <- toggle False terminalEvent
+  command <- hideableWidget'' terminalVisible "terminal" "terminal-hidden" $ do
+    terminalWidget ctx deltasDown hints
   footer ctx renderInfo
   let commandRequests = attachWithMaybe commandToRequest (current ensembleCDyn) command
   let ensembleRequests = leftmost [commandRequests, ensembleRequestFromPage,ensembleRequestsFromHints]

--- a/client/src/Estuary/Widgets/Footer.hs
+++ b/client/src/Estuary/Widgets/Footer.hs
@@ -17,11 +17,12 @@ import Estuary.Types.Response
 import Estuary.Types.Hint
 import qualified Estuary.Types.Term as Term
 import Estuary.Widgets.Generic
-import Estuary.Reflex.Utility (translateDyn)
+import Estuary.Reflex.Utility (translateDyn,dynButton)
 
 
-footer :: MonadWidget t m => Dynamic t Context -> Dynamic t RenderInfo -> m ()
+footer :: MonadWidget t m => Dynamic t Context -> Dynamic t RenderInfo -> m (Event t ())
 footer ctx renderInfo = divClass "footer" $ do
+  terminalButton <- el "div" $ dynButton "Terminal"
   divClass "peak primary-color code-font" $ do
     dynText =<< holdUniqDyn (fmap formatServerInfo ctx)
     text ", "
@@ -33,6 +34,7 @@ footer ctx renderInfo = divClass "footer" $ do
     text "FPS ("
     dynText =<< holdUniqDyn (fmap (showt . animationLoad) renderInfo)
     text "ms)"
+  return terminalButton
 
 formatServerInfo :: Context -> Text
 formatServerInfo c = showt cc <> " connections, latency " <> showt l <> "ms"

--- a/client/src/Estuary/Widgets/Footer.hs
+++ b/client/src/Estuary/Widgets/Footer.hs
@@ -22,7 +22,7 @@ import Estuary.Reflex.Utility (translateDyn,dynButton)
 
 footer :: MonadWidget t m => Dynamic t Context -> Dynamic t RenderInfo -> m (Event t ())
 footer ctx renderInfo = divClass "footer" $ do
-  terminalButton <- el "div" $ dynButton "Terminal"
+  terminalButton <- el "div" $ dynButton ">_"
   divClass "peak primary-color code-font" $ do
     dynText =<< holdUniqDyn (fmap formatServerInfo ctx)
     text ", "

--- a/client/src/Estuary/Widgets/Footer.hs
+++ b/client/src/Estuary/Widgets/Footer.hs
@@ -15,31 +15,24 @@ import Estuary.Types.RenderInfo
 import Estuary.Types.Request
 import Estuary.Types.Response
 import Estuary.Types.Hint
-import qualified Estuary.Types.Terminal as Terminal
 import qualified Estuary.Types.Term as Term
-import Estuary.Widgets.Terminal
 import Estuary.Widgets.Generic
 import Estuary.Reflex.Utility (translateDyn)
 
 
-footer :: MonadWidget t m => Dynamic t Context -> Dynamic t RenderInfo
-  -> Event t [Response] -> Event t [Hint] -> m (Event t Terminal.Command)
-footer ctx renderInfo deltasDown hints = do
-  let footerEvent = ffilter (elem ToggleTerminal) hints
-  footerVisible <- toggle False footerEvent
-  hideableWidget'' footerVisible "footer" "footer-hidden" $ do
-    divClass "peak primary-color code-font" $ do
-      dynText =<< holdUniqDyn (fmap formatServerInfo ctx)
-      text ", "
-      dynText =<< translateDyn Term.Load ctx
-      text " "
-      dynText =<< holdUniqDyn (fmap (showt . avgRenderLoad) renderInfo)
-      text "%,   "
-      dynText =<< holdUniqDyn (fmap (showt . animationFPS) renderInfo)
-      text "FPS ("
-      dynText =<< holdUniqDyn (fmap (showt . animationLoad) renderInfo)
-      text "ms)"
-    terminalWidget ctx deltasDown hints
+footer :: MonadWidget t m => Dynamic t Context -> Dynamic t RenderInfo -> m ()
+footer ctx renderInfo = divClass "footer" $ do
+  divClass "peak primary-color code-font" $ do
+    dynText =<< holdUniqDyn (fmap formatServerInfo ctx)
+    text ", "
+    dynText =<< translateDyn Term.Load ctx
+    text " "
+    dynText =<< holdUniqDyn (fmap (showt . avgRenderLoad) renderInfo)
+    text "%,   "
+    dynText =<< holdUniqDyn (fmap (showt . animationFPS) renderInfo)
+    text "FPS ("
+    dynText =<< holdUniqDyn (fmap (showt . animationLoad) renderInfo)
+    text "ms)"
 
 formatServerInfo :: Context -> Text
 formatServerInfo c = showt cc <> " connections, latency " <> showt l <> "ms"

--- a/client/src/Estuary/Widgets/Generic.hs
+++ b/client/src/Estuary/Widgets/Generic.hs
@@ -331,19 +331,18 @@ genericSignalWidget = elClass "div" "genericSignalWidget" $ do
   d <- button' "{}" MakeLayer
   return $ leftmost [b,c,d]
 
+-- Used heavily in Help section
+-- Contains the child in a hideable div with a class
 hideableWidget :: MonadWidget t m => Dynamic t Bool -> Text -> m a -> m a
 hideableWidget b c m = do
   let attrs = fmap (bool (fromList [("hidden","true"),("class",c)]) (singleton "class" c)) b
   elDynAttr "div" attrs m
 
+-- Used for the terminal
+-- Contains the child in a hideable div with no class
 hideableWidget' :: MonadWidget t m => Dynamic t Bool -> m a -> m a
 hideableWidget' b m = do
   let attrs = fmap (bool (fromList [("hidden","true")]) (fromList [("visible","true")])) b
-  elDynAttr "div" attrs m
-
-hideableWidget'' :: MonadWidget t m => Dynamic t Bool -> Text -> Text -> m a -> m a
-hideableWidget'' b c c2 m = do
-  let attrs = fmap (bool (fromList [("hidden","true"),("class",c2)]) (singleton "class" c)) b
   elDynAttr "div" attrs m
 
 traceDynamic :: (MonadWidget t m, Show a) => String -> Dynamic t a -> m (Dynamic t a)

--- a/static/css-source/source.css
+++ b/static/css-source/source.css
@@ -361,7 +361,7 @@ body::-webkit-scrollbar-thumb {
 /*modifies the chat messages (source)*/
 .chatMessageContainer {
 	overflow: auto;
-	height: 1em;
+	height: 7em;
 }
 
 .chatMessage {

--- a/static/css-source/source.css
+++ b/static/css-source/source.css
@@ -191,27 +191,20 @@ body::-webkit-scrollbar-thumb {
 	background-color: transparent;
 }
 
-
 .footer{
 	flex:none;
-/* 	flex-grow:0;
-	flex-shrink:1; */
 	display:flex;
-	flex-direction: row-reverse;
 	border: none;
 	padding-top: 5px;
 	padding-bottom: 5px;
 	padding-left: 15px;
 	padding-right: 15px;
+  justify-content: space-between;
 }
-
-
 
 .btn {
 	cursor: pointer;
 }
-
-
 
 /* source  */
 .peak{

--- a/static/css-source/source.css
+++ b/static/css-source/source.css
@@ -875,6 +875,10 @@ table, tr, td {border: none;}
 	background-color: transparent;
 }
 
+.terminalHidden {
+  display: none;
+}
+
 .joinButton {
 
 width: fit-content;

--- a/static/css-source/source.css
+++ b/static/css-source/source.css
@@ -166,7 +166,6 @@ body::-webkit-scrollbar-thumb {
 	left: 0px;
 	top: 0px;
 	border-top: 1px solid;
-	border-bottom: 1px solid;
 	padding-left: 15px;
 	padding-right: 15px;
 	overflow:hidden;
@@ -857,7 +856,7 @@ table, tr, td {border: none;}
 	flex: 1 1 auto;
 	padding-left: 0.7em;
 	overflow:hidden;
-
+  border-top: 1px solid;
 }
 
 .terminalHeader {


### PR DESCRIPTION
Separates the terminal from the footer and adds a button to the footer to toggle the terminal.
![Screen Shot 2020-04-10 at 10 16 12 AM](https://user-images.githubusercontent.com/6070190/78997864-6824e700-7b15-11ea-8ac5-f19022929d74.png)
