### PR TITLE
ensembleStatusWidget updates

### DIFF
--- a/client/src/Estuary/Widgets/EnsembleStatus.hs
+++ b/client/src/Estuary/Widgets/EnsembleStatus.hs
@@ -33,53 +33,59 @@ ensembleStatusWidget = do
   let status = fmap wsStatus ctx --ensemble status
   let anonymous = fmap anonymousParticipants ens -- Dynamic t Int
 
-  -- display name of ensemble
   liftR $ divClass "ensemble-name code-font" $ do
     text "Ensemble: "
     dynText ensName
 
-    -- display list of known participants
   liftR2 (divClass "tableContainer") $ do
-    liftR2 (el "table") $ do
-       liftR $ el "tr" $ do
-          el "th" $ text ""
-          el "th" $ text ""
-          el "th" $ text ""
-          el "th" $ text ""
-          el "th" $ text ""
-
---
--- liftR2 (divClass "statusElementsWrapper") $ do
---     liftR $ divClass "statusElementWrapper code-font" $ do
---       divClass "statusElementName" $ do
---         text "Anonymous Participants: "
---         dynText $ fmap showt anonymous
-
-    -- display list of locations for known participants
-       liftR $ el "tr"  $ do
-          elClass "td"  "statusWidgetNameAndLocation" $ listWithKey ensParticipants participantAndLocationWidget
-          statusMonster <- elClass "td" "statusWidgetStatusInput" $ listWithKey ensParticipants participantStatusWidget
-          let statusEvent = switchDyn $ fmap (leftmost . elems) statusMonster --Event t EnsembleRequest
-          mapActivities <- pollParticipantActivity ensParticipants -- :: Dynamic t Map Text  Text
-          elClass "td" "statusWidgetActivity" $ listWithKey mapActivities participantActivityWidget -- m (Dynamic t (Map k a))
-          elClass "td" "statusWidgetFPS" $ listWithKey ensParticipants participantFPSWidget
-          elClass "td" "statusWidgetLatency" $ listWithKey ensParticipants participantLatencyWidget
+    status <- liftR2 (el "table") $ do
+        liftR $ do
+          -- get indiviual handler and pass it down as a pure value
+          now <- liftIO getCurrentTime -- this time is measured before building the widget
+          evTick <- tickLossy 10.13 now  -- m (Event t TickInfo)
+          currentTime <- performEvent $ fmap (\_ -> liftIO getCurrentTime) evTick
+          x <- listWithKey ensParticipants (row currentTime)
+          let statusEvent = switchDyn $ fmap (leftmost . elems) x --Event t EnsembleRequest
           return statusEvent
 
+    liftR $ divClass "statusWidgetAnonymousPart" $ do
+      text "Anonymous Participants: "
+      dynText $ fmap showt anonymous
 
+    return status
+
+row ::  MonadWidget t m  => Event t UTCTime -> Text -> Dynamic t Participant ->  m (Event t EnsembleRequest)
+row t name part = do
+  row <- el "tr" $ do
+    elClass "td" "statusWidgetNameAndLocation" $ participantNameAndLocationWidget name part
+    status <- elClass "td" "statusWidgetStatusInput" $ participantStatusWidget name part
+    elClass "td" "statusWidgetActivity" $ participantActivityWidget t name part
+    elClass "td" "statusWidgetFPS" $ participantFPSWidget name part
+    elClass "td" "statusWidgetLatency" $ participantLatencyWidget name part
+    return status
+  return (row)
+
+-- participantStatusWidget :: MonadWidget t m  => Text -> Text -> Dynamic t Participant -> m (Event t EnsembleRequest)
 participantStatusWidget :: MonadWidget t m  => Text -> Dynamic t Participant -> m (Event t EnsembleRequest)
+-- participantStatusWidget thisUserhandle _ part = do
 participantStatusWidget _ part = do
   initialStatus <- status <$> sample (current part)
   let updatedStatus = fmap status (updated part)  --Event t Participant -> Event t Text -- and event that changes the text
+  -- style <- -- dynamic style -- compare their handle in their ensemble and this user, current user's handle is in the initial value context (do this function somewhere else)
   s <- textInput $ def & textInputConfig_setValue .~ updatedStatus & textInputConfig_initialValue .~ initialStatus & attributes .~ constDyn ("class" =: "code-font")
+  -- ("style" =: ".avoid-clicks { pointer-events: none;}")
   let writeStatusToServer = fmap (\x -> WriteStatus x) $ _textInput_input s --msg only sent when they press a key
   return writeStatusToServer
 
-participantAndLocationWidget :: MonadWidget t m => Text -> Dynamic t Participant -> m ()
-participantAndLocationWidget name part = do
-  text $ name <> "@"
-  dynText $ fmap location part
-  el "br" $ blank
+participantNameAndLocationWidget :: MonadWidget t m => Text -> Dynamic t Participant -> m ()
+participantNameAndLocationWidget name part = do
+  dynText $ constDyn name <> fmap location' part
+
+location' :: Participant -> Text
+location' p = f (location p)
+  where
+    f x | x == "" = x
+        | otherwise = "@" <> x
 
 participantNameWidget :: MonadWidget t m => Text -> Dynamic t Participant -> m ()
 participantNameWidget name part = text name
@@ -90,33 +96,24 @@ participantLocationWidget name part = dynText $ fmap location part
 participantFPSWidget :: MonadWidget t m => Text -> Dynamic t Participant -> m ()
 participantFPSWidget name part = do
   let a = fmap (showt . animationLoad) part
-  dynText a
-  text "FPS "
+  dynText $ a <> (constDyn "FPS")
 
 participantLatencyWidget :: MonadWidget t m => Text -> Dynamic t Participant -> m ()
 participantLatencyWidget name part = elClass "div" "" $ do
-  let a = fmap (T.pack. show . latency) part
-  dynText a
+  let a = fmap (T.pack . show . floor . realToFrac . (*) 1000 . latency) part
+  dynText $ a <> (constDyn "ms")
 
+participantActivityWidget :: MonadWidget t m => Event t UTCTime -> Text -> Dynamic t Participant -> m ()
+participantActivityWidget t name part = divClass "" $ do
+   x <- pollParticipantActivity t part
+   dynText x
 
-participantActivityWidget :: MonadWidget t m => Text -> Dynamic t Text -> m ()
-participantActivityWidget name part = divClass "" $ do
-  dynText part
-  el "br" $ blank
-
-
-pollParticipantActivity :: MonadWidget t m => Dynamic t (Map Text Participant) ->  m (Dynamic t (Map Text Text))  -- :: Dynamic t Map Text  Text
-pollParticipantActivity ensParticipants = do
-  now <- liftIO getCurrentTime -- this time is measured before building the widget
-  evTick <- tickLossy 10.13 now  -- m (Event t TickInfo)
-  currentTime <- performEvent $ fmap (\_ -> liftIO getCurrentTime) evTick
-  let ev = attachWith generateActivityMessages (current ensParticipants) currentTime
-  ip <- sample $ current ensParticipants
-  let im = generateActivityMessages ip now
-  holdDyn im ev
-
-generateActivityMessages :: Map Text Participant -> UTCTime -> Map Text Text
-generateActivityMessages m t = fmap (flip generateActivityMessage $ t) m
+pollParticipantActivity :: MonadWidget t m => Event t UTCTime -> Dynamic t Participant -> m (Dynamic t Text)
+pollParticipantActivity e part = do
+  now <- liftIO getCurrentTime
+  iv <- fmap (\x -> generateActivityMessage x now) $ sample $ current part -- initial v of part
+  let x = attachWith generateActivityMessage (current part) e -- :: Event t Text
+  holdDyn iv x -- :: event a -> m (Dyn a)
 
 generateActivityMessage :: Participant -> UTCTime -> Text
 generateActivityMessage p t = do

--- a/static/css-source/source.css
+++ b/static/css-source/source.css
@@ -1108,20 +1108,33 @@ display: inline-flex;
   width: 100%;
 }
 
-.statusWidgetNameAndLocation {
-	display: flex;
-	flex-wrap: nowrap   ;
+.tableContainer tr {
+
 }
+
+.tableContainer table,  td {
+	width: 100%;
+    border-bottom: 1px solid var(--primary-color);
+    border-collapse: collapse;
+}
+
+.statusWidgetNameAndLocation{
+		margin-bottom: 1%;
+		width: auto;
+}
+
 
 .statusWidgetStatusInput input {
 	color: var(--primary-color);
 	background-color: transparent;
 	border: none;
 	width: 99%;
+/* 	pointer-events: none; */
 }
 
-.tableContainer td {
-	width: 100%;
+
+.statusWidgetAnonymousPart {
+	text-align: center;
 }
 
 /* Tooltip classes */


### PR DESCRIPTION
This pull request includes the refactoring of the participant's row so it is generated dynamically. It also includes the 'proper' alignment of the elements of the table, the latency in ms, and the refactoring of the activity widget (done today at our meeting). Finally, now the table only shows the "@" symbol if the user has provided a location. This commit has been merged with dktr0's dev branch (building was successful too).