### PR TITLE
Add ensemble status to terminal

### DIFF
--- a/client/src/Estuary/Widgets/Terminal.hs
+++ b/client/src/Estuary/Widgets/Terminal.hs
@@ -24,33 +24,38 @@ import qualified Estuary.Types.Term as Term
 import qualified Estuary.Types.Terminal as Terminal
 import Estuary.Types.Hint
 import Estuary.Widgets.Editor
+import Estuary.Widgets.EnsembleStatus
 
 terminalWidget :: MonadWidget t m => Event t [Response] -> Event t [Hint] -> Editor t m (Event t Terminal.Command)
 terminalWidget deltasDown hints = divClass "terminal" $ mdo
-  (inputWidget) <- divClass "terminalHeader code-font primary-color" $ do
-    divClass "webSocketButtons" $ term Term.TerminalChat >>= dynText
-    let resetText = fmap (const "") terminalInput
-    let attrs = constDyn $ fromList [("class","primary-color code-font"),("style","width: 100%")]
-    inputWidget' <- divClass "terminalInput" $ textInput $ def & textInputConfig_setValue .~ resetText & textInputConfig_attributes .~ attrs
-    return (inputWidget')
-  let enterPressed = fmap (const ()) $ ffilter (==13) $ _textInput_keypress inputWidget
-  let terminalInput = tag (current $ _textInput_value inputWidget) $ leftmost [enterPressed]
-  let parsedInput = fmap Terminal.parseCommand terminalInput
-  let commands = fmapMaybe (either (const Nothing) Just) parsedInput
-  let errorMsgs = fmapMaybe (either (Just . (:[]) . ("Error: " <>) . T.pack . show) (const Nothing)) parsedInput
+  commands <- divClass "chat" $ mdo
+    (inputWidget) <- divClass "terminalHeader code-font primary-color" $ do
+      divClass "webSocketButtons" $ term Term.TerminalChat >>= dynText
+      let resetText = fmap (const "") terminalInput
+      let attrs = constDyn $ fromList [("class","primary-color code-font"),("style","width: 100%")]
+      inputWidget' <- divClass "terminalInput" $ textInput $ def & textInputConfig_setValue .~ resetText & textInputConfig_attributes .~ attrs
+      return (inputWidget')
+    let enterPressed = fmap (const ()) $ ffilter (==13) $ _textInput_keypress inputWidget
+    let terminalInput = tag (current $ _textInput_value inputWidget) $ leftmost [enterPressed]
+    let parsedInput = fmap Terminal.parseCommand terminalInput
+    let commands = fmapMaybe (either (const Nothing) Just) parsedInput
+    let errorMsgs = fmapMaybe (either (Just . (:[]) . ("Error: " <>) . T.pack . show) (const Nothing)) parsedInput
 
-  let hintMsgs = ffilter (/= []) $ fmap hintsToMessages hints
+    let hintMsgs = ffilter (/= []) $ fmap hintsToMessages hints
 
-  -- parse responses from server in order to display log/chat messages
-  let responseMsgs = fmap (Data.Maybe.mapMaybe responseToMessage) deltasDown
-  let streamIdMsgs = fmap (\x -> ["new Peer id: " <> x]) streamId
-  let messages = mergeWith (++) [responseMsgs,errorMsgs,hintMsgs,streamIdMsgs]
-  mostRecent <- foldDyn (\a b -> take 12 $ (reverse a) ++ b) [] messages
-  divClass "chatMessageContainer" $ simpleList mostRecent $ \v -> divClass "chatMessage code-font primary-color" $ dynText v
+    -- parse responses from server in order to display log/chat messages
+    let responseMsgs = fmap (Data.Maybe.mapMaybe responseToMessage) deltasDown
+    let streamIdMsgs = fmap (\x -> ["new Peer id: " <> x]) streamId
+    let messages = mergeWith (++) [responseMsgs,errorMsgs,hintMsgs,streamIdMsgs]
+    mostRecent <- foldDyn (\a b -> take 12 $ (reverse a) ++ b) [] messages
+    divClass "chatMessageContainer" $ simpleList mostRecent $ \v -> divClass "chatMessage code-font primary-color" $ dynText v
 
-  pp <- liftIO $ newPeerProtocol
-  startStreamingReflex pp $ ffilter (== Terminal.StartStreaming) commands
-  streamId <- peerProtocolIdReflex pp $ ffilter (== Terminal.StreamId) commands
+    pp <- liftIO $ newPeerProtocol
+    startStreamingReflex pp $ ffilter (== Terminal.StartStreaming) commands
+    streamId <- peerProtocolIdReflex pp $ ffilter (== Terminal.StreamId) commands
+    return commands
+
+  divClass "views ensembleStatus" $ ensembleStatusWidget
 
   return commands
 

--- a/client/src/Estuary/Widgets/Terminal.hs
+++ b/client/src/Estuary/Widgets/Terminal.hs
@@ -55,7 +55,7 @@ terminalWidget deltasDown hints = divClass "terminal" $ mdo
     streamId <- peerProtocolIdReflex pp $ ffilter (== Terminal.StreamId) commands
     return commands
 
-  divClass "views ensembleStatus" $ ensembleStatusWidget
+  divClass "ensembleStatus" $ ensembleStatusWidget
 
   return commands
 

--- a/static/css-source/source.css
+++ b/static/css-source/source.css
@@ -872,6 +872,11 @@ table, tr, td {border: none;}
   display: none;
 }
 
+.chat {
+  display: inline-block;
+  width: 60%;
+}
+
 .joinButton {
 
 width: fit-content;
@@ -913,6 +918,12 @@ cursor: pointer;
     text-align: center;
     width: fit-content;
 
+}
+
+.ensembleStatus {
+  display: inline-block;
+  width: 40%;
+  vertical-align: top;
 }
 
 /*

--- a/static/css-source/source.css
+++ b/static/css-source/source.css
@@ -874,7 +874,7 @@ table, tr, td {border: none;}
 
 .chat {
   display: inline-block;
-  width: 60%;
+  width: 50%;
 }
 
 .joinButton {
@@ -922,7 +922,7 @@ cursor: pointer;
 
 .ensembleStatus {
   display: inline-block;
-  width: 40%;
+  width: 50%;
   vertical-align: top;
 }
 
@@ -1081,6 +1081,7 @@ display: inline-flex;
   border: 1px solid var(--primary-color);
   border-radius: 5px;
   margin-bottom: 0.5%;
+  height: 7em;
 }
 
 .tableContainer::-webkit-scrollbar  {


### PR DESCRIPTION
Terminal is now split 50/50 between the chat and the ensemble status widget. Working with scroll bars too.
![Screen Shot 2020-04-18 at 4 34 14 PM](https://user-images.githubusercontent.com/6070190/79670663-baf44380-8192-11ea-824b-fc37b87c0089.png)
