### PR TITLE
Hideable title along with the rest of the top row

### DIFF
--- a/client/src/Estuary/Widgets/Header.hs
+++ b/client/src/Estuary/Widgets/Header.hs
@@ -21,7 +21,9 @@ header = divClass "header primary-color primary-borders" $ mdo
 
   let headerEvent = leftmost [() <$ headerButton]
   headerVisible <- toggle True headerEvent
-  headerButton <- clickableDiv "header-title" $ text "estuary"
+  headerButton <- clickableDiv "header-area" $ do
+    hideableWidget' headerVisible $ do
+      divClass "header-title" $ text "estuary"
 
   hideableWidget' headerVisible $ do
     divClass "config-toolbar" $ do

--- a/static/css-source/source.css
+++ b/static/css-source/source.css
@@ -166,7 +166,6 @@ body::-webkit-scrollbar-thumb {
 	position: relative; /* note that relative positioning with 0x0 is required here for SVG fdisplay */
 	left: 0px;
 	top: 0px;
-	border-top: 1px solid;
 	padding-left: 15px;
 	padding-right: 15px;
 	overflow:hidden;

--- a/static/css-source/source.css
+++ b/static/css-source/source.css
@@ -241,7 +241,6 @@ body::-webkit-scrollbar-thumb {
 }
 
 .config-entry {
-	border-right: 1px solid;
 	padding: 0.25em 0.5em;
 	display: inline-block;
 

--- a/static/css-source/source.css
+++ b/static/css-source/source.css
@@ -156,6 +156,7 @@ body::-webkit-scrollbar-thumb {
   overflow: hidden;
   white-space: nowrap;
   border: none;
+  height: 30px;
 }
 
 .page {
@@ -1320,6 +1321,12 @@ height: 6.5em;
   width: 50%;
   display: inline-block;
   text-align: end;
+  cursor: pointer;
+}
+
+.header-area {
+  width: 50%;
+  display: inline-block;
   cursor: pointer;
 }
 


### PR DESCRIPTION
Ended up just removing the top border from the CSS for `.page`. Think it looks cleaner anyway plus it was a time saver.