### PR TITLE
getting rid of wrapping bool from roulette widget

### DIFF
--- a/client/src/Estuary/Types/View/Parser.hs
+++ b/client/src/Estuary/Types/View/Parser.hs
@@ -26,15 +26,11 @@ dumpView (SequenceView z) = "sequence:" <> showInt z
 dumpView (BorderDiv v) = "border { " <> dumpView v <> "} "
 dumpView TempoView = "tempo"
 dumpView EnsembleStatusView = "ensembleStatus"
-dumpView (RouletteView x rows wrappingBool) = "roulette:" <> showInt x <> " " <> showInt rows <> " " <> showBool wrappingBool
+dumpView (RouletteView x rows) = "roulette:" <> showInt x <> " " <> showInt rows
 dumpView AudioMapView = "audiomapview"
 
 showInt :: Int -> Text
 showInt x = showtParen (x < 0) (showt x)
-
-showBool :: Bool -> Text
-showBool True = "True"
-showBool False = "False"
 
 viewsParser :: Parser View
 viewsParser = do
@@ -76,7 +72,7 @@ sequenceView = reserved "sequence" >> reservedOp ":" >> (SequenceView <$> int)
 ensembleStatusView = reserved "ensembleStatus" >> return EnsembleStatusView
 tempo = reserved "tempo" >> return TempoView
 textView = reserved "text" >> reservedOp ":" >> (TextView <$> int <*> int)
-rouletteView = reserved "roulette" >> reservedOp ":" >> (RouletteView <$> int <*> int <*> stringToBool)
+rouletteView = reserved "roulette" >> reservedOp ":" >> (RouletteView <$> int <*> int)
 audiomapview = reserved "audiomap" >> return AudioMapView
 
 int :: Parser Int
@@ -84,13 +80,6 @@ int = choice [
   parens $ (fromIntegral <$> integer),
   fromIntegral <$> integer
   ]
-
-stringToBool :: Parser Bool
-stringToBool = choice [
-  (string "True" >> return True),
-  (string "False" >> return False)
-  ]
-
 
 tokenParser :: P.GenTokenParser Text () Identity
 tokenParser = P.makeTokenParser $ P.LanguageDef {

--- a/client/src/Estuary/Types/View/Presets.hs
+++ b/client/src/Estuary/Types/View/Presets.hs
@@ -287,7 +287,7 @@ presetViews = fromList [
         ]),
 
       ("roulette",GridView 2 1 [
-        BorderDiv (Views [RouletteView 0 3, TextView 1 0]),
+        BorderDiv (Views [RouletteView 0 0, TextView 1 0]),
         BorderDiv (Views [RouletteView 2 0, TextView 3 0])
         ])
       ]

--- a/client/src/Estuary/Types/View/Presets.hs
+++ b/client/src/Estuary/Types/View/Presets.hs
@@ -286,8 +286,10 @@ presetViews = fromList [
          (Views [TempoView,EnsembleStatusView])
         ]),
 
+-- the second number of the RouletteView will modify the height of the view. It is set to ems, it is recommended to use numbers above 2 to avoid the roulette buttons to be cutoff. If set to 0, the roulette view will expand automatically and the text will wrap.
+
       ("roulette",GridView 2 1 [
-        BorderDiv (Views [RouletteView 0 0, TextView 1 0]),
-        BorderDiv (Views [RouletteView 2 0, TextView 3 0])
+        BorderDiv (Views [RouletteView 0 2, TextView 1 0]),
+        BorderDiv (Views [RouletteView 2 2, TextView 3 0])
         ])
       ]

--- a/client/src/Estuary/Types/View/Presets.hs
+++ b/client/src/Estuary/Types/View/Presets.hs
@@ -287,7 +287,7 @@ presetViews = fromList [
         ]),
 
       ("roulette",GridView 2 1 [
-        BorderDiv (Views [RouletteView 0 0 True, TextView 1 0]),
-        BorderDiv (Views [RouletteView 2 0 True, TextView 3 0])
+        BorderDiv (Views [RouletteView 0 3, TextView 1 0]),
+        BorderDiv (Views [RouletteView 2 0, TextView 3 0])
         ])
       ]

--- a/client/src/Estuary/Widgets/Roulette.hs
+++ b/client/src/Estuary/Widgets/Roulette.hs
@@ -33,13 +33,13 @@ getHead [] = []
 getHead xs = [head xs]
 
 
-rouletteWidget :: MonadWidget t m => Int -> Bool -> Dynamic t Roulette -> Editor t m (Variable t Roulette)
-rouletteWidget rows wrappingBool delta = do
+rouletteWidget :: MonadWidget t m => Int -> Dynamic t Roulette -> Editor t m (Variable t Roulette)
+rouletteWidget rows delta = do
   let rows' = 1 + rows
-  let attrsRouletteWidgetContainer = case rows of 0 -> constDyn $ ("class" =: "rouletteWidgetContainer  primary-color code-font") --  <> "style" =: (wrappingRoulette wrappingBool))
+  let attrsRouletteWidgetContainer = case rows of 0 -> constDyn $ ("class" =: "rouletteWidgetContainer  primary-color code-font")
                                                   _ -> constDyn $ ("class" =: "rouletteWidgetContainer  primary-color code-font" <> "style" =: ("height: " <> (T.pack (show rows') <> "em;"))) --  <> (wrappingRoulette wrappingBool)))
 
-  let attrsRouletteContainer = case rows of 0 -> constDyn $ ("class" =: "rouletteContainer"  <> "style" =: (wrappingRoulette wrappingBool))
+  let attrsRouletteContainer = case rows of 0 -> constDyn $ ("class" =: "rouletteContainer"  <> "style" =: "flex-wrap: nowrap;")
                                             _ -> constDyn $ ("class" =: "rouletteContainer" <> "style" =: "flex-wrap: wrap;")
 
   elDynAttr "div" attrsRouletteWidgetContainer $ do
@@ -55,13 +55,10 @@ rouletteWidget' delta = mdo
     let currentValUnion =  liftM2 (++) currentValHead  currentValTail
 
     -- roulette buttons/ not on a different colour, underlining or circling or subtle. Inverse colors, inverse the background and the font.
-    let attrsRouletteButton' = attrsRouletteButton uHandle
-    listOfRouletteButtonsHead <- simpleList currentValHead (rouletteButton attrsRouletteButtonHead)  -- m (Dynamic [Event t (Roulette -> Roulette)])
-    listOfRouletteButtonsTail <- simpleList currentValTail (rouletteButton attrsRouletteButtonTail) -- m (Dynamic [Event t (Roulette -> Roulette)])
+    listOfRouletteButtonsHead <- simpleList currentValHead (rouletteButton $ attrsRouletteButtonHead uHandle)  -- m (Dynamic [Event t (Roulette -> Roulette)])
+    listOfRouletteButtonsTail <- simpleList currentValTail (rouletteButton $ attrsRouletteButtonTail uHandle) -- m (Dynamic [Event t (Roulette -> Roulette)])
     let listOfRouletteButtons = liftM2 (++) listOfRouletteButtonsHead listOfRouletteButtonsTail
     let deleteEv = switchDyn $ fmap leftmost listOfRouletteButtons
-    -- let attrsRouletteButton' = attrsRouletteButton uHandle'(true,sometext)   --  Map Text Text
-    -- listOfRouletteButtons <- simpleList currentValTail (rouletteButton attrsRouletteButton') -- m (Dynamic [Event t (Roulette -> Roulette)])
 
     -- lineup button
     let dynAttrs = attrsLineUpButton <$> fmap (currentlyLinedUp uHandle) currentVal
@@ -73,14 +70,6 @@ rouletteWidget' delta = mdo
     x <- returnVariable delta newValue
     currentVal <- holdUniqDyn $ currentValue x
     return x
-
--- controls if the content of the rows wrap
-wrappingRoulette :: Bool -> Text
-wrappingRoulette b = wrap b
-  where
-    wrap False  = "display: flex; flex-wrap: nowrap;"
-    wrap True = "display: flex; flex-wrap: wrap;"
-
 
 -- Dynamic t a (comes from the server, and only is the initial value and it also represents the udpates) -> Event t a (come from local user actions) -> Variable t Roulette
 currentlyLinedUp :: Text -> [Text] -> Bool
@@ -96,29 +85,22 @@ rouletteButton attrs label = do
   return $ attachWith (\x _ -> removeHandleFromList x) (current label) clickEv
 
 
-attrsRouletteButton :: Text -> Map Text Text
-attrsRouletteButton uhandle
-  | uhandle == "" = "class" =: "rouletteButtons ui-buttons code-font" <> "style" =: "cursor: not-allowed; pointer-events: none;"
-  | otherwise = "class" =: "rouletteButtons ui-buttons code-font"
+-- attrsRouletteButton :: Text -> Map Text Text
+-- attrsRouletteButton uhandle
+--   | uhandle == "" = "class" =: "rouletteButtons ui-buttons code-font" <> "style" =: "cursor: not-allowed; pointer-events: none;"
+--   | otherwise = "class" =: "rouletteButtons ui-buttons code-font"
 
--- merge
--- 1. finish class of buttons background
--- 2. finish sizing
--- work: 1hr (figuring out how to modify the list) + 20 min css
+attrsRouletteButtonHead :: Text -> Map Text Text
+attrsRouletteButtonHead uhandle
+  | uhandle == "" = "class" =: "rouletteButtons ui-buttons code-font attrsRouletteButtonHead" <> "style" =: "cursor: not-allowed; pointer-events: none;"
+  | otherwise = "class" =: "rouletteButtons ui-buttons code-font attrsRouletteButtonHead"
 
-attrsRouletteButtonHead :: Map Text Text
-attrsRouletteButtonHead = "class" =: "rouletteButtons ui-buttons attrsRouletteButtonHead"
 
-attrsRouletteButtonTail :: Map Text Text
-attrsRouletteButtonTail = "class" =: "rouletteButtons ui-buttons attrsRouletteButtonTail"
+attrsRouletteButtonTail :: Text ->  Map Text Text
+attrsRouletteButtonTail uhandle
+  | uhandle == "" = "class" =: "rouletteButtons ui-buttons code-font attrsRouletteButtonTail" <> "style" =: "cursor: not-allowed; pointer-events: none;"
+  | otherwise = "class" =: "rouletteButtons ui-buttons code-font attrsRouletteButtonTail"
 
--- attrsRouletteButton :: Text -> Roulette -> Map Text Text
--- attrsRouletteButton uhandle xs
---   |uhandle == (head xs) = "class" =: "rouletteButtons ui-buttons code-font" <> "style" =: "cursor: not-allowed; pointer-events: none; color: white"
---   |otherwise = "class" =: "rouletteButtons ui-buttons code-font"
-
- -- m (Dynamic [Event t (Roulette -> Roulette)])
--- z :: MonadWidget t m =>
 
 lineUpButton ::  MonadWidget t m => Dynamic t (Map Text Text) -> Text -> (Roulette -> Roulette) -> m (Event t (Roulette -> Roulette))
 lineUpButton attrs label r = do
@@ -137,7 +119,6 @@ attrsLineUpButton b = "class" =: "lineUpButton ui-buttons other-borders code-fon
     colour False =  "color:var(--primary-color)"
     colour True =  "color: var(--secondary-color)"
 
-
 rouletteToRoulette :: Dynamic t Roulette -> Dynamic t Roulette
 rouletteToRoulette xs = xs
 
@@ -149,8 +130,7 @@ addHandleToList uHandle roulette
 --addHandleToList "luis" -- Roulette -> Roulette -- check if the name is in the list already and add if not.
 -- Both of these func should be pure funcs.
 
--- e.g. deleteHandleFromL :: Text -> Roulette -> Roulette
--- deleteHandleFromL -- fail silently , i.e. return the existing list
-
+-- e.g. removeHandleFromList :: Text -> Roulette -> Roulette
+-- deleteHandlremoveHandleFromListeFromL -- fail silently , i.e. return the existing list
 removeHandleFromList :: Text -> Roulette -> Roulette
 removeHandleFromList handle xs = Prelude.filter (\e -> e/=handle) xs

--- a/client/src/Estuary/Widgets/Roulette.hs
+++ b/client/src/Estuary/Widgets/Roulette.hs
@@ -39,7 +39,7 @@ rouletteWidget rows delta = do
   let attrsRouletteWidgetContainer = case rows of 0 -> constDyn $ ("class" =: "rouletteWidgetContainer  primary-color code-font")
                                                   _ -> constDyn $ ("class" =: "rouletteWidgetContainer  primary-color code-font" <> "style" =: ("height: " <> (T.pack (show rows') <> "em;"))) --  <> (wrappingRoulette wrappingBool)))
 
-  let attrsRouletteContainer = case rows of 0 -> constDyn $ ("class" =: "rouletteContainer"  <> "style" =: "flex-wrap: nowrap;")
+  let attrsRouletteContainer = case rows of 0 -> constDyn $ ("class" =: "rouletteContainer"  <> "style" =: "flex-wrap: wrap;")
                                             _ -> constDyn $ ("class" =: "rouletteContainer" <> "style" =: "flex-wrap: wrap;")
 
   elDynAttr "div" attrsRouletteWidgetContainer $ do

--- a/client/src/Estuary/Widgets/View.hs
+++ b/client/src/Estuary/Widgets/View.hs
@@ -58,7 +58,7 @@ viewWidget er (SequenceView z) = zoneWidget z defaultValue maybeSequence Sequenc
 viewWidget er EnsembleStatusView = ensembleStatusWidget
 
 -- viewWidget er (RouletteView z rows) = rouletteWidget
-viewWidget er (RouletteView z rows wrappingBool) = zoneWidget z [] maybeRoulette Roulette er (rouletteWidget rows wrappingBool)
+viewWidget er (RouletteView z rows) = zoneWidget z [] maybeRoulette Roulette er (rouletteWidget rows)
 
 viewWidget er TempoView = do
   ctx <- context

--- a/common/src/Estuary/Types/View.hs
+++ b/common/src/Estuary/Types/View.hs
@@ -24,7 +24,7 @@ data View =
   Example TextNotation Text | -- a clickable text-code example
   EnsembleStatusView |
   TempoView |
-  RouletteView Int Int Bool|
+  RouletteView Int Int|
   AudioMapView
   deriving (Show,Eq,Generic)
 


### PR DESCRIPTION
Hi David, 

This pull request is for removing the bool that we originally designated for wrapping and expanding the roulette. Now, the behaviour is that when the roulette rows are set to 0/auto, the text wraps, and the div expands accordingly. With rows set to 1/2/3/etc the text wraps too, but the dive do **not** expand beyond the given rows. Finally, I've modified the roulette preset so its height is set to a default of 2 em. I merged with your dev branch before starting to work today.

