### PR TITLE
Fixed text positioning, added border parser

### DIFF
--- a/client/src/Estuary/Help/CineCer0/CineCer0Reference.hs
+++ b/client/src/Estuary/Help/CineCer0/CineCer0Reference.hs
@@ -92,7 +92,7 @@ funcionsCineCer0 = el "div" $ do
     el "li" $ elClass "div" "ieRef" $ text "vol 0.3 $ \"videos/lamplight.mp4\""
   -- Text
   el "div" $ dynText =<< (translatableText $ fromList [
-    (English,"\n Text fucntions:"),
+    (English,"\n Text functions:"),
     (Español,"\n Funciones de texto:")
     ])
   el "div" $ dynText =<< (translatableText $ fromList [

--- a/client/src/Estuary/Languages/CineCer0/CineCer0State.hs
+++ b/client/src/Estuary/Languages/CineCer0/CineCer0State.hs
@@ -102,6 +102,12 @@ addVideo j os = do
     previousVol = 0
   }
 
+-- addInvisibleText :: HTMLDivElement -> LayerSpec -> IO CineCer0Text
+-- addInvisibleText j ls = do
+--   cct <- addText j ls
+--   let inv = invisibleText cct 
+--   return inv
+
 addText :: HTMLDivElement -> LayerSpec -> IO CineCer0Text
 addText j os = do
   let texto = layerToString $ layer os
@@ -112,6 +118,11 @@ addText j os = do
     positionLockTx = 0,
     previousStyleTx = ""
   }
+
+-- invisibleText :: CineCer0Text -> IO CineCer0Text
+-- invisibleText tx = do 
+--     _setTextStyle (textLayer tx) "visibility: hidden;"
+--     return $ tx { previousStyleTx = "" }
 
 layerToString:: Either String String -> Text
 layerToString (Right x) = T.pack $ x
@@ -178,7 +189,7 @@ updateContinuingText t eTime rTime (sw,sh) s tx = logExceptions tx $ do
  tw <- textWidth j
  th <- textHeight j
 
- if (tw /= 0) then (putStrLn "WIIIDTHHHH!!!!") else (putStrLn "no width yet")
+-- if (tw /= 0) then (putStrLn "WIIIDTHHHH!!!!") else (putStrLn "no width yet")
 
  -- putStrLn $ show (T.split (== ' ') $ layerToString (layer s))
  -- putStrLn $ (show $ tw) <> " width" 
@@ -187,9 +198,9 @@ updateContinuingText t eTime rTime (sw,sh) s tx = logExceptions tx $ do
  -- putStrLn $ (show $ sh) <> " div height"
  -- putStrLn $ (show $ xPos) <> " calculated x pos"
 
- if (sw /= 0 && sh /= 0) then do
+ if (tw /= 0 && th /= 0) then do
   let aTime = anchorTime s t eTime
-  let lengthOfLayer = 1
+  let lengthOfLayer = 1  -- think about how to get a length for a text
   let txFont = (fontFamily s t lengthOfLayer rTime eTime aTime)
   let striked = generateStrike (strike s t lengthOfLayer rTime eTime aTime)
   let bolded = generateBold (bold s t lengthOfLayer rTime eTime aTime)
@@ -215,6 +226,7 @@ updateContinuingText t eTime rTime (sw,sh) s tx = logExceptions tx $ do
   --let topY = yPos
   let x = realToFrac $ (posX s t lengthOfLayer rTime eTime aTime)
   let y = realToFrac $ (posY s t lengthOfLayer rTime eTime aTime)
+
    -- calculate xPos
   let xPos' = sw - tw 
   let xPos  = xPos' * (0.5 + (x*0.5))
@@ -227,7 +239,6 @@ updateContinuingText t eTime rTime (sw,sh) s tx = logExceptions tx $ do
   let txStyle = textStyle (realToFrac $ leftX) (realToFrac $ topY) (realToFrac $ actualWidth) (realToFrac $ actualHeight) (T.pack txFont) striked bolded italicised coloured sized z'
   -- putStrLn $ T.unpack $ txStyle -- debugging line
   setTextStyle tx $ txStyle
-
   else return tx
 
 updateContinuingVideo :: Tempo -> UTCTime -> UTCTime -> (Double,Double) -> LayerSpec -> CineCer0Video -> IO CineCer0Video
@@ -308,7 +319,7 @@ generateFilter Nothing Nothing Nothing Nothing Nothing Nothing = ""
 generateFilter o bl br c g s = "filter:" <> generateOpacity o <> generateBlur bl <> generateBrightness br <> generateContrast c <> generateGrayscale g <> generateSaturate s <>";"
 
 videoStyle :: Double -> Double -> Double -> Double -> Text -> Text -> Text -> Text
-videoStyle x y w h f m z = "left: " <> showt (x) <> "px; top: " <> showt (y) <> "px; position: absolute; width:" <> showt (w) <> "px; height:" <> showt (h) <> "px; object-fit: fill;" <> f <> m <> z
+videoStyle x y w h f m z = "left: " <> showt x <> "px; top: " <> showt y <> "px; position: absolute; width:" <> showt (w) <> "px; height:" <> showt (h) <> "px; object-fit: fill;" <> f <> m <> z
 
 
 generateZIndex :: Int -> Text
@@ -352,7 +363,7 @@ generateItalic (True) = "; font-style: italic;"
 generateItalic (False) = ""
 
 textStyle :: Double -> Double -> Double -> Double -> Text -> Text -> Text -> Text -> Text -> Text -> Text -> Text
-textStyle x y w h ff stk bld itc clr sz z = "position: absolute;" <> "left: " <> showt x <> "px; top: " <> showt y <> "px; border: 1px solid #cccccc; text-align: center;" <> "font-family:" <> showt ff <> stk <> bld <> itc <> clr <> sz <> z <> ";"
+textStyle x y w h ff stk bld itc clr sz z = "visibility: visible; position: absolute;" <> "left: " <> showt (x-1) <> "px; top: " <> showt y <> "px; border: 1px solid #cccccc; text-align: center;" <> "font-family:" <> showt ff <> stk <> bld <> itc <> clr <> sz <> z <> ";"
 
 
 -- textStyle :: Double -> Double -> Double -> Double -> Text -> Text -> Text -> Text -> Text -> Text -> Text -> Text

--- a/client/src/Estuary/Languages/CineCer0/CineCer0State.hs
+++ b/client/src/Estuary/Languages/CineCer0/CineCer0State.hs
@@ -327,7 +327,7 @@ generateZIndex :: Int -> Text
 generateZIndex n = "; z-index: " <> T.pack (show n) <> ";"
 
 generateFontSize :: Double -> Text
-generateFontSize size = "; font-size: " <> T.pack (show size) <> "px;"
+generateFontSize size = "; font-size: " <> T.pack (show (size)) <> "em;"
 
 generateColours:: Colour -> Tempo -> NominalDiffTime -> UTCTime -> UTCTime -> UTCTime -> Text  -- this string needs to be a text!!!!
 generateColours (Colour str) t ll rT eT aT = "; color: " <> T.pack (string) <> ";"  

--- a/client/src/Estuary/Languages/CineCer0/CineCer0State.hs
+++ b/client/src/Estuary/Languages/CineCer0/CineCer0State.hs
@@ -205,6 +205,7 @@ updateContinuingText t eTime rTime (sw,sh) s tx = logExceptions tx $ do
   let striked = generateStrike (strike s t lengthOfLayer rTime eTime aTime)
   let bolded = generateBold (bold s t lengthOfLayer rTime eTime aTime)
   let italicised = generateItalic (italic s t lengthOfLayer rTime eTime aTime)
+  let bordered = generateBorder (border s t lengthOfLayer rTime eTime aTime)
   let coloured = generateColours (colour s) t lengthOfLayer rTime eTime aTime
   let sized = generateFontSize (realToFrac $ (fontSize s t lengthOfLayer rTime eTime aTime))
 
@@ -236,7 +237,7 @@ updateContinuingText t eTime rTime (sw,sh) s tx = logExceptions tx $ do
   let yPos  = yPos' * (0.5 + (y*(-0.5)))
   let topY = yPos
 
-  let txStyle = textStyle (realToFrac $ leftX) (realToFrac $ topY) (realToFrac $ actualWidth) (realToFrac $ actualHeight) (T.pack txFont) striked bolded italicised coloured sized z'
+  let txStyle = textStyle (realToFrac $ leftX) (realToFrac $ topY) (realToFrac $ actualWidth) (realToFrac $ actualHeight) (T.pack txFont) striked bolded italicised bordered coloured sized z'
   -- putStrLn $ T.unpack $ txStyle -- debugging line
   setTextStyle tx $ txStyle
   else return tx
@@ -362,8 +363,12 @@ generateItalic :: Bool -> Text
 generateItalic (True) = "; font-style: italic;"
 generateItalic (False) = ""
 
-textStyle :: Double -> Double -> Double -> Double -> Text -> Text -> Text -> Text -> Text -> Text -> Text -> Text
-textStyle x y w h ff stk bld itc clr sz z = "visibility: visible; position: absolute;" <> "left: " <> showt (x-1) <> "px; top: " <> showt y <> "px; border: 1px solid #cccccc; text-align: center;" <> "font-family:" <> showt ff <> stk <> bld <> itc <> clr <> sz <> z <> ";"
+generateBorder :: Bool -> Text
+generateBorder (True) = "; border: 1px solid #cccccc;"
+generateBorder (False) = ""
+
+textStyle :: Double -> Double -> Double -> Double -> Text -> Text -> Text -> Text -> Text -> Text -> Text -> Text -> Text
+textStyle x y w h ff stk bld itc brd clr sz z = "visibility: visible; position: absolute;" <> "left: " <> showt (x-1) <> "px; top: " <> showt y <> "px;" <> "text-align: center;" <> "font-family:" <> showt ff <> stk <> bld <> itc <> brd <> clr <> sz <> z <> ";"
 
 
 -- textStyle :: Double -> Double -> Double -> Double -> Text -> Text -> Text -> Text -> Text -> Text -> Text -> Text

--- a/client/src/Estuary/Languages/CineCer0/Parser.hs
+++ b/client/src/Estuary/Languages/CineCer0/Parser.hs
@@ -169,7 +169,8 @@ vs_vs =
   sigInt_vs_vs <*> sigInt <|>
   (reserved "strike" >> return setStrike) <|>
   (reserved "bold" >> return setBold) <|>
-  (reserved "italic" >> return setItalic)
+  (reserved "italic" >> return setItalic) <|>
+  (reserved "border" >> return setBorder)
   -- <|>
  -- (reserved "mute" >> return setMute) <|>
  -- (reserved "unmute" >> return setUnmute)

--- a/client/src/Estuary/Languages/CineCer0/VideoSpec.hs
+++ b/client/src/Estuary/Languages/CineCer0/VideoSpec.hs
@@ -65,7 +65,7 @@ emptyLayerSpec = LayerSpec {
   volume = constantSignal 0.0,
 
   fontFamily = constantSignal "sans-serif",
-  fontSize = constantSignal 100,
+  fontSize = constantSignal 1,
   colour = Colour (constantSignal "White"),
   strike = constantSignal False,
   bold = constantSignal False,

--- a/client/src/Estuary/Languages/CineCer0/VideoSpec.hs
+++ b/client/src/Estuary/Languages/CineCer0/VideoSpec.hs
@@ -64,7 +64,7 @@ emptyLayerSpec = LayerSpec {
   volume = constantSignal 0.0,
 
   fontFamily = constantSignal "sans-serif",
-  fontSize = constantSignal 200,
+  fontSize = constantSignal 100,
   colour = Colour (constantSignal "White"),
   strike = constantSignal False,
   bold = constantSignal False,

--- a/client/src/Estuary/Languages/CineCer0/VideoSpec.hs
+++ b/client/src/Estuary/Languages/CineCer0/VideoSpec.hs
@@ -33,6 +33,7 @@ data LayerSpec = LayerSpec {
   strike :: Signal Bool,
   bold :: Signal Bool,
   italic :: Signal Bool,
+  border :: Signal Bool,
 
   posX :: Signal Rational,
   posY :: Signal Rational,
@@ -69,6 +70,7 @@ emptyLayerSpec = LayerSpec {
   strike = constantSignal False,
   bold = constantSignal False,
   italic = constantSignal False,
+  border = constantSignal False,
 
   posX = constantSignal 0.0,
   posY = constantSignal 0.0,
@@ -167,6 +169,9 @@ setBold tx = tx { bold = constantSignal True}
 
 setItalic :: LayerSpec -> LayerSpec
 setItalic tx = tx { italic = constantSignal True}
+
+setBorder :: LayerSpec -> LayerSpec
+setBorder tx = tx { border = constantSignal True}
 
 setColourStr :: Signal String -> LayerSpec -> LayerSpec
 setColourStr clr tx = tx { colour = Colour clr }


### PR DESCRIPTION
I have successfully fixed the positioning of the text in cinecero. Now the only way to control the size of the text is via fontSize. The invisible-when-added mechanism is still in process. I also added border to the parser so: border $ text "hola" will generate a text with a 1px width white solid border. Next time I will add background color as backgroundColour, backgroundHSVA and backgroundRGBA. 