### PR TITLE
Calendar widget reworked with widgetMapEventWithAdd

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -6,7 +6,7 @@ This document will outline how to customize Estuary's interface themes.
 
 - Within estuary's main folder look for the 'static' folder. Inside 'static', access to the 'css-custom' folder.
 
-- Insde 'css-custom' you'll find Estuary's current themes. You can explore all of them to see how they are put together.
+- Inside 'css-custom' you'll find Estuary's current themes. You can explore all of them to see how they are put together.
 
 - To create a new theme, create a new css file inside of the 'css-custom' folder. To get started, copy the code from one of the current themes in your new css file.
 

--- a/client/estuary.cabal
+++ b/client/estuary.cabal
@@ -135,7 +135,7 @@ library
     , reflex-dom
     , reflex-dom-core
     , safe
---    , seis8s
+    , seis8s
     , split
     , tempi
     , text
@@ -186,7 +186,7 @@ executable Estuary
     , reflex-dom
     , reflex-dom-core
     , safe
---    , seis8s
+    , seis8s
     , split
     , tempi
     , text
@@ -246,7 +246,7 @@ executable interaction-test
     , reflex-dom
     , reflex-dom-core
     , safe
---    , seis8s
+    , seis8s
     , split
     , tempi
     , text
@@ -304,7 +304,7 @@ executable simple-test
     , reflex-dom
     , reflex-dom-core
     , safe
---    , seis8s
+    , seis8s
     , split
     , tempi
     , text
@@ -360,7 +360,7 @@ test-suite clientTest
     , reflex-dom
     , reflex-dom-core
     , safe
---    , seis8s
+    , seis8s
     , split
     , tempi
     , text

--- a/client/src/Estuary/Render/Renderer.hs
+++ b/client/src/Estuary/Render/Renderer.hs
@@ -38,7 +38,7 @@ import Sound.MusicW.AudioContext
 import qualified Sound.TimeNot.AST as TimeNot
 import qualified Sound.TimeNot.Parsers as TimeNot
 import qualified Sound.TimeNot.Render as TimeNot
--- import qualified Sound.Seis8s.Parser as Seis8s
+import qualified Sound.Seis8s.Parser as Seis8s
 import Estuary.Languages.Punctual
 import Estuary.Languages.CineCer0
 import Estuary.Languages.LocoMotion
@@ -391,7 +391,7 @@ renderTextProgramChanged c z (TimeNot,x,eTime) = do
       modify' $ \xx -> xx { timeNots = insert z p (timeNots xx) }
     Left e -> setZoneError z (T.pack $ show e)
 
-{- renderTextProgramChanged c z (Seis8s,x,eTime) = do
+renderTextProgramChanged c z (Seis8s,x,eTime) = do
   let parseResult = Seis8s.parseLang $ T.unpack x
   case parseResult of
     Right p -> do
@@ -399,7 +399,7 @@ renderTextProgramChanged c z (TimeNot,x,eTime) = do
       setBaseNotation z Seis8s
       setEvaluationTime z eTime
       modify' $ \xx -> xx { seis8ses = insert z p $ seis8ses xx }
-    Left e -> setZoneError z (T.pack $ show e) -}
+    Left e -> setZoneError z (T.pack $ show e)
 
 renderTextProgramChanged c z (JSoLang x,y,eTime) = do
   parseResult <- liftIO $ JSoLang.define y
@@ -469,7 +469,8 @@ renderBaseProgramAlways c z _ (Just TimeNot) = do
       let oTime = firstCycleStartAfter theTempo eTime
       pushNoteEvents $ fmap TimeNot.mapForEstuary $ TimeNot.render oTime p' wStart wEnd
     Nothing -> return ()
-{- renderBaseProgramAlways c z _ (Just Seis8s) = do
+
+renderBaseProgramAlways c z _ (Just Seis8s) = do
   s <- get
   let p = IntMap.lookup z $ seis8ses s
   case p of
@@ -478,7 +479,8 @@ renderBaseProgramAlways c z _ (Just TimeNot) = do
       let wStart = renderStart s
       let wEnd = renderEnd s
       pushNoteEvents $ Seis8s.render p' theTempo wStart wEnd
-    Nothing -> return () -}
+    Nothing -> return ()
+
 renderBaseProgramAlways _ _ _ _ = return ()
 
 renderControlPattern :: Context -> Int -> R ()

--- a/client/src/Estuary/Types/RenderState.hs
+++ b/client/src/Estuary/Types/RenderState.hs
@@ -24,7 +24,7 @@ import qualified Estuary.Languages.CineCer0.CineCer0State as CineCer0
 import qualified Estuary.Languages.CineCer0.Spec as CineCer0
 import qualified Estuary.Languages.CineCer0.Parser as CineCer0
 import qualified Sound.TimeNot.AST as TimeNot
--- import qualified Sound.Seis8s.Program as Seis8s
+import qualified Sound.Seis8s.Program as Seis8s
 import qualified Estuary.Languages.Hydra.Render as Hydra
 import Estuary.Languages.JSoLang
 
@@ -45,7 +45,7 @@ data RenderState = RenderState {
   cineCer0Specs :: !(IntMap CineCer0.Spec),
   cineCer0States :: !(IntMap CineCer0.CineCer0State),
   timeNots :: IntMap TimeNot.Program,
-  -- seis8ses :: IntMap Seis8s.Program,
+  seis8ses :: IntMap Seis8s.Program,
   hydras :: IntMap Hydra.Hydra,
   evaluationTimes :: IntMap UTCTime, -- this is probably temporary
   renderTime :: !MovingAverage,
@@ -88,7 +88,7 @@ initialRenderState pIn pOut cvsElement glCtx hCanvas lCanvas t0System t0Audio = 
     cineCer0Specs = empty,
     cineCer0States = empty,
     timeNots = empty,
-    -- seis8ses = empty,
+    seis8ses = empty,
     hydras = empty,
     evaluationTimes = empty,
     renderTime = newAverage 20,

--- a/client/src/Estuary/Types/View/Presets.hs
+++ b/client/src/Estuary/Types/View/Presets.hs
@@ -30,7 +30,7 @@ presetViews = fromList [
       ("test",  GridView 2 3  [
       (Views [LabelView 1, CalendarEventView 2]),
       (Views [LabelView 3, CodeView 4 0 ["fluxus"] ]),
-      (Views [LabelView 5, SequenceView 6 ]),
+      (Views [LabelView 5, CodeView 6 0 []]),
       (Views [LabelView 7, CodeView 8 0 [] ]),
       (Views [LabelView 9, CodeView 10 0 [] ]),
       (Views [LabelView 11, CodeView 12 0 [] ])

--- a/client/src/Estuary/Types/View/Presets.hs
+++ b/client/src/Estuary/Types/View/Presets.hs
@@ -30,7 +30,7 @@ presetViews = fromList [
       ("test",  GridView 2 3  [
       (Views [LabelView 1, CalendarEventView 2]),
       (Views [LabelView 3, CodeView 4 0 ["fluxus"] ]),
-      (Views [LabelView 5, CodeView 6 0 [] ]),
+      (Views [LabelView 5, SequenceView 6 ]),
       (Views [LabelView 7, CodeView 8 0 [] ]),
       (Views [LabelView 9, CodeView 10 0 [] ]),
       (Views [LabelView 11, CodeView 12 0 [] ])

--- a/client/src/Estuary/Types/View/Presets.hs
+++ b/client/src/Estuary/Types/View/Presets.hs
@@ -29,7 +29,7 @@ presetViews = fromList [
 
       ("test",  GridView 2 3  [
       (Views [LabelView 1, CalendarEventView 2]),
-      (Views [LabelView 3, CodeView 4 0]),
+      (Views [LabelView 3, SequenceView 4]),
       (Views [LabelView 5, CodeView 6 0]),
       (Views [LabelView 7, CodeView 8 0]),
       (Views [LabelView 9, CodeView 10 0]),

--- a/client/src/Estuary/Widgets/Sequencer.hs
+++ b/client/src/Estuary/Widgets/Sequencer.hs
@@ -15,7 +15,7 @@ import Estuary.Types.Hint
 import Estuary.Widgets.Reflex
 import Estuary.Widgets.Reflex
 import Estuary.Widgets.W
-
+ 
 
 type Sequence = Map Int (Text, [Bool])
 

--- a/client/src/Estuary/Widgets/Sequencer.hs
+++ b/client/src/Estuary/Widgets/Sequencer.hs
@@ -15,7 +15,7 @@ import Estuary.Types.Hint
 import Estuary.Widgets.Reflex
 import Estuary.Widgets.Reflex
 import Estuary.Widgets.W
- 
+
 
 type Sequence = Map Int (Text, [Bool])
 

--- a/client/src/Estuary/Widgets/View.hs
+++ b/client/src/Estuary/Widgets/View.hs
@@ -115,9 +115,15 @@ viewWidget er EnsembleStatusView = ensembleStatusWidget
 
 viewWidget er (RouletteView z rows) = zoneWidget z [] maybeRoulette Roulette er (rouletteWidget rows)
 
+-- viewWidget er (CalendarEventView z) = do
+--   today <- liftIO getZonedTime
+--   zoneWidget z (CalendarEvent "Add a title" (CalendarTime today (Recurrence Once today))) maybeCalendarEvent CalendarEv er calendarEventWidget
+
+
 viewWidget er (CalendarEventView z) = do
   today <- liftIO getZonedTime
-  zoneWidget z (CalendarEvent "Add a title" (CalendarTime today (Recurrence Once today))) maybeCalendarEvent CalendarEv er calendarEventWidget
+  zoneWidget z (IntMap.fromList [(1, CalendarEvent "Add a title" (CalendarTime today (Recurrence Once today)))]) maybeCalendarEvents CalendarEvs er calendarEventWidget'
+
 
 viewWidget er (CountDownView z) = zoneWidget z (Holding 60) maybeTimerDownState CountDown er countDownWidget
 

--- a/client/src/Estuary/Widgets/View.hs
+++ b/client/src/Estuary/Widgets/View.hs
@@ -115,16 +115,10 @@ viewWidget er EnsembleStatusView = ensembleStatusWidget
 
 viewWidget er (RouletteView z rows) = zoneWidget z [] maybeRoulette Roulette er (rouletteWidget rows)
 
--- viewWidget er (CalendarEventView z) = do
---   today <- liftIO getZonedTime
---   zoneWidget z (CalendarEvent "Add a title" (CalendarTime today (Recurrence Once today))) maybeCalendarEvent CalendarEv er calendarEventWidget
-
-
 viewWidget er (CalendarEventView z) = do
   today <- liftIO getZonedTime
+  let defaultValue = IntMap.singleton 0 (CalendarEvent "Add a title" (CalendarTime today (Recurrence Once today)))
   zoneWidget z defaultValue maybeCalendarEvents CalendarEvs er calendarEventWidget
-    where defaultValue = Map.singleton 0 (CalendarEvent "Add a title" (CalendarTime today (Recurrence Once today)))
-
 
 viewWidget er (CountDownView z) = zoneWidget z (Holding 60) maybeTimerDownState CountDown er countDownWidget
 

--- a/client/src/Estuary/Widgets/View.hs
+++ b/client/src/Estuary/Widgets/View.hs
@@ -122,7 +122,8 @@ viewWidget er (RouletteView z rows) = zoneWidget z [] maybeRoulette Roulette er 
 
 viewWidget er (CalendarEventView z) = do
   today <- liftIO getZonedTime
-  zoneWidget z (IntMap.fromList [(1, CalendarEvent "Add a title" (CalendarTime today (Recurrence Once today)))]) maybeCalendarEvents CalendarEvs er calendarEventWidget'
+  zoneWidget z defaultValue maybeCalendarEvents CalendarEvs er calendarEventWidget'
+    where defaultValue = Map.singleton 0 (CalendarEvent "Add a title" (CalendarTime today (Recurrence Once today)))
 
 
 viewWidget er (CountDownView z) = zoneWidget z (Holding 60) maybeTimerDownState CountDown er countDownWidget

--- a/common/src/Estuary/Types/Definition.hs
+++ b/common/src/Estuary/Types/Definition.hs
@@ -28,7 +28,7 @@ type NotePad = (Int,Seq NotePage)
 type NotePage = (Text,Text)
 type CalendarEvents = M.Map Int CalendarEvent
 
-data CalendarEvent = CalendarEvent Text CalendarTime deriving (Eq, Show, Generic)
+data CalendarEvent = CalendarEvent Bool Text CalendarTime deriving (Eq, Show, Generic)
 data CalendarTime = CalendarTime { startingDate :: ZonedTime, recurrence :: Recurrence } deriving  (Eq, Show, Generic)
 data Recurrence = Recurrence { periodicity :: Periodicity, endDate :: ZonedTime} deriving  (Eq, Show, Generic)
 data Periodicity =  Once | Daily | DailyUntil | Weekly | WeeklyUntil | MonthlyXDay| MonthlyXDayUntil | Yearly| YearlyUntil deriving  (Eq, Show, Generic)

--- a/common/src/Estuary/Types/Definition.hs
+++ b/common/src/Estuary/Types/Definition.hs
@@ -10,6 +10,9 @@ import GHC.Generics
 import Data.Aeson
 import Data.Time
 import Data.Sequence
+import qualified Data.IntMap as IntMap
+
+
 
 import Estuary.Tidal.Types
 import Estuary.Types.Live
@@ -23,6 +26,8 @@ type Sequence = M.Map Int (Text,[Bool])
 type Roulette = [Text]
 type NotePad = (Int,Seq NotePage)
 type NotePage = (Text,Text)
+
+type CalendarEvents = IntMap.IntMap CalendarEvent
 
 data CalendarEvent = CalendarEvent Text CalendarTime deriving (Eq, Show, Generic)
 data CalendarTime = CalendarTime { startingDate :: ZonedTime, recurrence :: Recurrence } deriving  (Eq, Show, Generic)
@@ -87,7 +92,9 @@ data Definition =
   StopWatch TimerUpState |
   SeeTime TimeVision |
   NotePad NotePad |
-  CalendarEv CalendarEvent
+  CalendarEv CalendarEvent |
+  CalendarEvs CalendarEvents
+
   deriving (Eq,Show,Generic)
 
 instance ToJSON Definition where
@@ -146,6 +153,13 @@ maybeRoulette _ = Nothing
 
 justRoulettes :: [Definition] -> [Roulette]
 justRoulettes = mapMaybe maybeRoulette
+
+maybeCalendarEvents :: Definition -> Maybe CalendarEvents
+maybeCalendarEvents (CalendarEvs x) = (Just x)
+maybeCalendarEvents _ = Nothing
+
+justCalendarEvents :: [Definition] -> [CalendarEvents]
+justCalendarEvents = mapMaybe maybeCalendarEvents
 
 maybeCalendarEvent :: Definition -> Maybe CalendarEvent
 maybeCalendarEvent (CalendarEv x) = Just x

--- a/common/src/Estuary/Types/Definition.hs
+++ b/common/src/Estuary/Types/Definition.hs
@@ -10,8 +10,6 @@ import GHC.Generics
 import Data.Aeson
 import Data.Time
 import Data.Sequence
-import qualified Data.IntMap as IntMap
-
 
 
 import Estuary.Tidal.Types
@@ -26,12 +24,12 @@ type Sequence = M.Map Int (Text,[Bool])
 type Roulette = [Text]
 type NotePad = (Int,Seq NotePage)
 type NotePage = (Text,Text)
-type CalendarEvents = M.Map Int CalendarEvent
+type CalendarEvents = IntMap.IntMap CalendarEvent
 
-data CalendarEvent = CalendarEvent Bool Text CalendarTime deriving (Eq, Show, Generic)
+data CalendarEvent = CalendarEvent Text CalendarTime deriving (Eq, Show, Generic)
 data CalendarTime = CalendarTime { startingDate :: ZonedTime, recurrence :: Recurrence } deriving  (Eq, Show, Generic)
 data Recurrence = Recurrence { periodicity :: Periodicity, endDate :: ZonedTime} deriving  (Eq, Show, Generic)
-data Periodicity =  Once | Daily | DailyUntil | Weekly | WeeklyUntil | MonthlyXDay| MonthlyXDayUntil | Yearly| YearlyUntil deriving  (Eq, Show, Generic)
+data Periodicity =  Once | Daily | DailyUntil | Weekly | WeeklyUntil | MonthlyDate | MonthlyDateUntil | MonthlyNthDayOfWeek | MonthlyNthDayOfWeekUntil | Yearly | YearlyUntil deriving  (Eq, Show, Generic)
 
 
 -- data Periodicity =  Once | Daily | DailyUntil | Weekly | WeeklyUntil | MonthlyXDay| MonthlyXDayUntil | MonthlyFirstXDay | MonthlyFirstXDayUntil | MonthlySecondXDay | MonthlySecondXDayUntil | MonthlyThirdXDay | MonthlyThirdXDayUntil| MonthlyFourthXDay | MonthlyFourthXDayUntil | MonthlyLastXDay | MonthlyLastXDayUntil | Yearly| YearlyUntil deriving  (Eq, Show, Generic)

--- a/common/src/Estuary/Types/Definition.hs
+++ b/common/src/Estuary/Types/Definition.hs
@@ -26,8 +26,7 @@ type Sequence = M.Map Int (Text,[Bool])
 type Roulette = [Text]
 type NotePad = (Int,Seq NotePage)
 type NotePage = (Text,Text)
-
-type CalendarEvents = IntMap.IntMap CalendarEvent
+type CalendarEvents = M.Map Int CalendarEvent
 
 data CalendarEvent = CalendarEvent Text CalendarTime deriving (Eq, Show, Generic)
 data CalendarTime = CalendarTime { startingDate :: ZonedTime, recurrence :: Recurrence } deriving  (Eq, Show, Generic)

--- a/default.nix
+++ b/default.nix
@@ -198,14 +198,14 @@ in
 
         tempi = self.callHackage "tempi" "1.0.2.1" {};
 
-        # we will won't be able to build this until reflex-dom-contrib dependency is removed
-        #seis8s = #dontHaddock (self.callCabal2nix "seis8s" ../seis8s {});
-        #  doJailbreak (dontHaddock (self.callCabal2nix "seis8s" (pkgs.fetchFromGitHub {
-        #   owner = "luisnavarrodelangel";
-        #   repo = "seis8s";
-        #   sha256 = "1nnzsmkcy28k1s1s72ckq136564r2d6xzngm2bd1sm5ixasxx0lq";
-        #   rev = "6edbf1e21ade2669a0098d3120c698463c86f52a";
-         #}) {}));
+        seis8s = #dontHaddock (self.callCabal2nix "seis8s" ../seis8s {});
+          doJailbreak (dontHaddock (self.callCabal2nix "seis8s" (pkgs.fetchFromGitHub {
+           owner = "luisnavarrodelangel";
+           repo = "seis8s";
+           sha256 = "169rfxknyv8ali87n6pmfpdm2vy09khsx4c9spa40sisskbbmlsz";
+           rev = "1db0e3ff1399e176792e815df748c62aff9aa227";
+
+         }) {}));
 
          permutation = markUnbroken super.permutation;
 


### PR DESCRIPTION
This pull request includes the reworking of the calendar widget using widgetMapEventWithAdd. It works smoothly! I also took the time to create the options of "monthly nth weekday" and "monthly nth weekday until" which were pending. These update to a "3rd Monday of each month" for example whereas the options "Monthly date" and "Monthly date until" update to the "15th of each month" for example. Now we have all four options. I made a pull request up to this point. 

TODO: I will continue working on calendar event details such as getting rid of the seconds and milliseconds on the times displayed, fixing minor CSS issues for the time displayer, and making calendars always display the current month (I discovered they currently display the month of the selected date). 

Thank you, 
Luis
